### PR TITLE
browserify error message

### DIFF
--- a/lib/server/browserify.js
+++ b/lib/server/browserify.js
@@ -46,10 +46,21 @@ async function compile(file, values) {
   try {
     return await tryBPKG(input, values);
   } catch (e) {
-    if (e.code === 'ERR_NOT_INSTALLED')
-      return tryBrowserify(input, values);
-    throw e;
+    if (e.code !== 'ERR_NOT_INSTALLED')
+      throw e;
   }
+
+  try {
+    return await tryBrowserify(input, values);
+  } catch (e) {
+    if (e.code !== 'ERR_NOT_INSTALLED')
+      throw e;
+  }
+
+  const err =  new Error('Neither bpkg nor browserify is installed.');
+  err.code = 'ERR_NOT_INSTALLED';
+
+  throw err;
 }
 
 async function tryBPKG(input, values) {


### PR DESCRIPTION
Error message is misleading, I did not notice it was trying bpkg first.
So instead of showing last error I combined those so you can choose what to install.