### PR TITLE
server: destroy socket.

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -549,6 +549,7 @@ class Server extends EventEmitter {
       case 'close': {
         process.exitCode = args[1] >>> 0;
         req.destroy();
+        req.socket.destroy();
         return this.close();
       }
     }


### PR DESCRIPTION
Previously browser + headless would close, because `req.destroy` would close the `connection/socket` as well (ECONNRESET).


Since `v16.0.0` - https://github.com/nodejs/node/pull/33035
This is no longer the case, `req.destroy` will just emit `close` event on the `request` not the socket. So headless chrome will keep its keep-alive connection (leading to timeout failures in bcrypto test suite for the browser)

This will destroy socket when `close` is requested from the `browser test runner`.